### PR TITLE
Change the launcher script to only wrap the binary

### DIFF
--- a/brave.sh
+++ b/brave.sh
@@ -42,4 +42,4 @@ export XCURSOR_PATH=$(echo "$XDG_DATA_DIRS" | sed 's,\(:\|$\),/icons\1,g')
 export CHROME_WRAPPER=$(readlink -f "$0")
 export TMPDIR="$XDG_RUNTIME_DIR/app/$FLATPAK_ID"
 
-exec zypak-wrapper.sh /app/brave/brave-browser "$@"
+exec zypak-wrapper.sh /app/brave/brave "$@"


### PR DESCRIPTION
Otherwise, it wraps the shell script launcher, which causes a lot of crashes from Zypak interfering with random shell commands.

Fixes #11.