### PR TITLE
Support sourcing host policy files from /etc/brave into sandbox.

### DIFF
--- a/brave.sh
+++ b/brave.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/bash -x
+
+# Merge the policies with the host ones.
+policy_root=/etc/brave/policies
+
+for policy_type in managed recommended; do
+  policy_dir="$policy_root/$policy_type"
+  mkdir -p "$policy_dir"
+
+  if [[ "$policy_type" == 'managed' ]]; then
+    ln -sf /app/share/flatpak-chrome/flatpak_policy.json "$policy_dir"
+  fi
+
+  if [[ -d "/run/host/$policy_root/$policy_type" ]]; then
+    find "/run/host/$policy_root/$policy_type" -name '*.json' \
+      -exec ln -sf '{}' "$policy_root/$policy_type" \;
+  fi
+done
+
+exec cobalt "$@"

--- a/brave.sh
+++ b/brave.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash -x
+#!/usr/bin/bash
 
 # Merge the policies with the host ones.
 policy_root=/etc/brave/policies
@@ -12,7 +12,8 @@ for policy_type in managed recommended; do
   fi
 
   if [[ -d "/run/host/$policy_root/$policy_type" ]]; then
-    find "/run/host/$policy_root/$policy_type" -name '*.json' \
+    find "/run/host/$policy_root/$policy_type" \
+      -maxdepth 1 -name '*.json' -type f \
       -exec ln -sf '{}' "$policy_root/$policy_type" \;
   fi
 done

--- a/com.brave.Browser.yaml
+++ b/com.brave.Browser.yaml
@@ -150,3 +150,5 @@ modules:
         path: flatpak_policy.json
       - type: file
         path: brave-browser.desktop
+      - type: file
+        path: brave.sh


### PR DESCRIPTION
As discussed here https://github.com/flathub/com.brave.Browser/issues/103#issuecomment-1024704718 it seems that making proper extension attach points is impossible without rebuilding Brave. Maybe this could work as an interim solution for getting policy files into sandbox.

Brave already requests `host-etc` permission so there's no additional security impact. 

Thanks for considering. This stuff is important for my workflow and I'd rather not maintain custom package of Brave. :)