### PR TITLE
Add support for reading system proxy settings

### DIFF
--- a/com.brave.Browser.yaml
+++ b/com.brave.Browser.yaml
@@ -37,7 +37,16 @@ finish-args:
   - --filesystem=xdg-download
   - --filesystem=xdg-music
   - --filesystem=xdg-videos
-  - --filesystem=xdg-desktop
+  - --filesystem=xdg-pictures
+  # For GNOME proxy resolution
+  - --filesystem=xdg-run/dconf
+  - --filesystem=~/.config/dconf:ro
+  - --talk-name=ca.desrt.dconf
+  - --env=DCONF_USER_CONFIG_DIR=.config/dconf
+  - --env=GIO_EXTRA_MODULES=/app/lib/gio/modules
+  - --env=GSETTINGS_BACKEND=dconf
+  # For KDE proxy resolution (KDE5 only)
+  - --filesystem=~/.config/kioslaverc
   - --filesystem=/run/.heim_org.h5l.kcm-socket
   - --persist=.pki
 modules:


### PR DESCRIPTION
This exposes the host GNOME (via dconf) & KDE proxy settings, so Chrome can read them directly. If proxy support is not needed, the user can of course just remove these new permissions.

Closes #229