### PR TITLE
Update to enable FIDO2 support

### DIFF
--- a/com.brave.Browser.yaml
+++ b/com.brave.Browser.yaml
@@ -14,6 +14,7 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=cups
+  - --socket=pcsc # FIDO2
   - --socket=pulseaudio
   - --socket=x11
   - --socket=wayland


### PR DESCRIPTION
Enabling the pcsc socket to enable FIDO2 support.