### PR TITLE
Revert "Remove unnecessary permissions (#321)"

### DIFF
--- a/com.brave.Browser.yaml
+++ b/com.brave.Browser.yaml
@@ -30,13 +30,16 @@ finish-args:
   - --talk-name=org.gnome.Mutter.IdleMonitor.*
   - --system-talk-name=org.freedesktop.Avahi
   - --own-name=org.mpris.MediaPlayer2.chromium.*
-  - --filesystem=xdg-run/pipewire-0
-  # To load policies on the host /etc/brave/policies
   - --filesystem=host-etc
-  # To install a PWA application
   - --filesystem=home/.local/share/applications:create
   - --filesystem=home/.local/share/icons:create
+  - --filesystem=xdg-run/pipewire-0
   - --filesystem=xdg-desktop
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-download
+  - --filesystem=xdg-music
+  - --filesystem=xdg-videos
+  - --filesystem=xdg-pictures
   # For GNOME proxy resolution
   - --filesystem=xdg-run/dconf
   - --filesystem=~/.config/dconf:ro


### PR DESCRIPTION
PR #321 introduces breaking changes to the the Flatpak specifically the functionality of `xdg-portal` file picker that result in the picker always defaulting to `/home/[user]` every time the user tries to save or open a file.

The latest accessed path is no longer being remembered, causing a bad user experience and making it difficult to use many features, including:
- `brave://settings/downloads -> Location` - The option to change the downloads location path is broken as the file picker will still always defaults to `/home/[user]`.
- Similarly, any option, feature or extention in the browser that utilizes the file picker is also affected, resulting in a bad user experience where the user has to manually choose the download(or preferred) location for every file save or open.

The reverted permissions are necessary for a good UX.