### PR TITLE
Remove unnecessary filesystem permissions

### DIFF
--- a/com.brave.Browser.yaml
+++ b/com.brave.Browser.yaml
@@ -29,16 +29,15 @@ finish-args:
   - --talk-name=org.gnome.Mutter.IdleMonitor.*
   - --system-talk-name=org.freedesktop.Avahi
   - --own-name=org.mpris.MediaPlayer2.chromium.*
+  - --filesystem=xdg-run/pipewire-0
+  # To load policies on the host /etc/brave/policies
   - --filesystem=host-etc
+  # To install a PWA application
   - --filesystem=home/.local/share/applications:create
   - --filesystem=home/.local/share/icons:create
-  - --filesystem=xdg-run/pipewire-0
   - --filesystem=xdg-desktop
-  - --filesystem=xdg-documents
+  # For default download directory to work as expected (PR #324)
   - --filesystem=xdg-download
-  - --filesystem=xdg-music
-  - --filesystem=xdg-videos
-  - --filesystem=xdg-pictures
   # For GNOME proxy resolution
   - --filesystem=xdg-run/dconf
   - --filesystem=~/.config/dconf:ro


### PR DESCRIPTION
- xdg-portal filepicker already allows the user to choose files, without sharing entire directories to the sandbox
- xdg-download is left alone for the sake of #324