### PR TITLE
Enabling Wayland automatically when available on user system

### DIFF
--- a/brave-browser.desktop
+++ b/brave-browser.desktop
@@ -108,7 +108,7 @@ Comment[zh_TW]=連線到網際網路
 StartupNotify=true
 StartupWMClass=brave-browser
 TryExec=brave
-Exec=brave %U
+Exec=brave %U --enable-features=UseOzonePlatform --ozone-platform-hint=auto
 Terminal=false
 Icon=com.brave.Browser
 Type=Application


### PR DESCRIPTION
See https://groups.google.com/a/chromium.org/g/ozone-reviews/c/I90r4vR593I?pli=1

This should make Brave choose to use Wayland when available and fallback to x11 otherwise.