### PR TITLE
Disable default browser check

### DIFF
--- a/com.brave.Browser.yaml
+++ b/com.brave.Browser.yaml
@@ -50,6 +50,8 @@ finish-args:
   - --filesystem=~/.config/kioslaverc
   - --filesystem=/run/.heim_org.h5l.kcm-socket
   - --persist=.pki
+  # Avoid constant requests to set as default browser
+  - --no-default-browser-check
 modules:
   - name: dconf
     buildsystem: meson


### PR DESCRIPTION
Brave can still be set as the default browser in settings. This prevents the user from being presented with constant spam claiming that Brave isn't the default browser, even when it is

Upstream issue: https://github.com/brave/brave-browser/issues/30791
This resolves: https://github.com/flathub/com.brave.Browser/issues/356