### PR TITLE
github actions: Update to checkout v4

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         branch: [ master, beta ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ matrix.branch }}
       - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest


### PR DESCRIPTION
Use the current version of github's checkout ci script. This runs on a node20 base which has a longer support lifetime.