### PR TITLE
Enable multiarch in flatpak finish-args

### DIFF
--- a/com.brave.Browser.yaml
+++ b/com.brave.Browser.yaml
@@ -9,6 +9,7 @@ separate-locales: false
 build-options:
   no-debuginfo: true
 finish-args:
+  - --allow=multiarch
   - --device=all
   - --env=GTK_PATH=/app/lib/gtkmodules
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons


### PR DESCRIPTION
Required as the obfs4proxy Brave distributes is i386.

Closes #577