### PR TITLE
Add talk permissions to non-freedesktop dbus screensaver apis

### DIFF
--- a/com.brave.Browser.yaml
+++ b/com.brave.Browser.yaml
@@ -29,7 +29,11 @@ finish-args:
   - --talk-name=org.kde.kwalletd5
   - --talk-name=org.kde.kwalletd6
   - --talk-name=org.gnome.SessionManager
+  - --talk-name=org.gnome.ScreenSaver
   - --talk-name=org.gnome.Mutter.IdleMonitor.*
+  - --talk-name=org.cinnamon.ScreenSaver
+  - --talk-name=org.mate.ScreenSaver
+  - --talk-name=org.xfce.ScreenSaver
   - --system-talk-name=org.freedesktop.Avahi
   - --own-name=org.mpris.MediaPlayer2.brave.*
   - --filesystem=xdg-run/pipewire-0


### PR DESCRIPTION
Had a user reporting locking not working in the Bitwarden browser extension on the Flatpak version of Brave. Chromium talks to more than just the freedesktop screensaver dbus interface (cf. https://github.com/chromium/chromium/blob/140ebdb86130d4a1bc3c5b08448897ea5c5bda56/ui/base/idle/idle_linux.cc#L44-L55) . This PR adds permission for the missing screensaver dbus apis.