### PR TITLE
Revert "Enable multiarch in flatpak finish-args"

### DIFF
--- a/com.brave.Browser.yaml
+++ b/com.brave.Browser.yaml
@@ -9,7 +9,6 @@ separate-locales: false
 build-options:
   no-debuginfo: true
 finish-args:
-  - --allow=multiarch
   - --device=all
   - --env=GTK_PATH=/app/lib/gtkmodules
   - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons


### PR DESCRIPTION
This is no longer required as the obfs4proxy that Brave ships is native 64-bit now.

```
$ file apfggiafobakjahnkchiecbomjgigkkn/1.0.6/tor-obfs4-brave
apfggiafobakjahnkchiecbomjgigkkn/1.0.6/tor-obfs4-brave: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, Go BuildID=NQ4chrEaJylCMIoV890r/1ZI_vRnQd3rqH8WFB89L/qCbezzXANURIo0jtqM_s/JI4BKsuRn5FdYKcE0sqS, with debug_info, not stripped
```

This reverts commit 917594a6988397365e6725fa23a7e99c55b4ad8a.