### PR TITLE
Use freedesktop 24.08 SDK & runtime

### DIFF
--- a/com.brave.Browser.yaml
+++ b/com.brave.Browser.yaml
@@ -1,9 +1,9 @@
 app-id: com.brave.Browser
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 base: org.chromium.Chromium.BaseApp
-base-version: '23.08'
+base-version: '24.08'
 command: brave
 separate-locales: false
 build-options:


### PR DESCRIPTION
As the new stable version of Freedesktop SDK is released. This PR updates the SDK and runtime to freedesktop 24.08.