### PR TITLE
Improve support for group policies

### DIFF
--- a/brave.sh
+++ b/brave.sh
@@ -1,17 +1,13 @@
-#!/usr/bin/bash
+#!/bin/sh
 
 # Merge the policies with the host ones.
-policy_root=/etc/brave/policies
-
-for policy_type in managed recommended enrollment; do
-  policy_dir="$policy_root/$policy_type"
-  mkdir -p "$policy_dir"
-
-  if [[ -d "/run/host/$policy_root/$policy_type" ]]; then
-    find "/run/host/$policy_root/$policy_type" -type f -name '*' \
-      -maxdepth 1 -name '*.json' -type f \
-      -exec ln -sf '{}' "$policy_root/$policy_type" \;
-  fi
+for proot in "etc/brave/policies" "etc/static/brave/policies"; do
+  for ptype in managed recommended enrollment; do
+    if [ -d "/run/host/$proot/$ptype" ]; then
+      mkdir -p "/etc/brave/policies/$ptype"
+      ln -sf "/run/host/$proot/$ptype"/*.json "/etc/brave/policies/$ptype" 2>/dev/null
+    fi
+  done
 done
 
 exec cobalt "$@" --no-default-browser-check


### PR DESCRIPTION
Make brave.sh POSIX compliant.
Enable resolving of symlinks visible by flatpak.
Search in /etc/static/brave/policies directory used by NixOS and probably others.

(cherry picked from commit d9aad800113b8a858c204ae96505a21b458235ee)
Signed-off-by: rany <ranygh@riseup.net>