### PR TITLE
[BETA] Remove publish-delay-hours setting

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -4,6 +4,5 @@
     "aarch64"
   ],
   "automerge-flathubbot-prs": true,
-  "disable-external-data-checker": true,
-  "publish-delay-hours": 0
+  "disable-external-data-checker": true
 }


### PR DESCRIPTION
This doesn't do anything anymore with the migration to Vorarbeiter (https://github.com/flathub-infra/vorarbeiter).