### PR TITLE
Set the release channel explicitly

### DIFF
--- a/com.brave.Browser.yaml
+++ b/com.brave.Browser.yaml
@@ -58,6 +58,8 @@ finish-args:
   - --env=DCONF_USER_CONFIG_DIR=.config/dconf
   - --env=GIO_EXTRA_MODULES=/app/lib/gio/modules
   - --env=GSETTINGS_BACKEND=dconf
+  # Set the release channel correctly
+  - --env=CHROME_VERSION_EXTRA=stable
   # For KDE proxy resolution (KDE5 only)
   - --filesystem=~/.config/kioslaverc
 modules:


### PR DESCRIPTION
Fixes brave/brave-browser#45987 (Griffin not working at all)