### PR TITLE
Update filesystem path for Brave policies

### DIFF
--- a/com.brave.Browser.yaml
+++ b/com.brave.Browser.yaml
@@ -39,7 +39,7 @@ finish-args:
   - --filesystem=/run/.heim_org.h5l.kcm-socket
   - --filesystem=xdg-run/pipewire-0
   # To load policies on the host /etc/brave/policies
-  - --filesystem=host-etc
+  - --filesystem=host-etc/brave
   # To install a PWA application
   - --filesystem=home/.local/share/applications:create
   - --filesystem=home/.local/share/icons:create


### PR DESCRIPTION
Update access permission to /etc/brave/policies to restrict access to Brave's config path specifically. You can still open files on disk by typing CTRL+o since the operation is handled by the file chooser of the desktop environment (`org.freedesktop.FileManager1`)

If we ever need access to files in host-etc outside of `/etc/brave`, we can add it with a read-only flag `ro`.